### PR TITLE
Add hibernate option

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -35,6 +35,10 @@
       <default>true</default>
     </entry>
 
+    <entry name="showHibernate" type="Bool">
+      <default>true</default>
+    </entry>
+
     <entry name="showRestart" type="Bool">
       <default>true</default>
     </entry>
@@ -77,6 +81,10 @@
 
     <entry name="sleep" type="String">
       <default>systemctl suspend</default>
+    </entry>
+
+    <entry name="hibernate" type="String">
+      <default>systemctl hibernate</default>
     </entry>
 
     <entry name="restart" type="String">

--- a/package/contents/ui/config/ConfigGeneral.qml
+++ b/package/contents/ui/config/ConfigGeneral.qml
@@ -18,6 +18,7 @@ Item {
   property alias cfg_showAppStore: showAppStore.checked
   property alias cfg_showForceQuit: showForceQuit.checked
   property alias cfg_showSleep: showSleep.checked
+  property alias cfg_showHibernate: showHibernate.checked
   property alias cfg_showRestart: showRestart.checked
   property alias cfg_showShutdown: showShutdown.checked
   property alias cfg_showLockScreen: showLockScreen.checked
@@ -152,6 +153,10 @@ Item {
       QQC2.CheckBox {
         id: showSleep
         text: i18n('Sleep')
+      }
+      QQC2.CheckBox {
+        id: showHibernate
+        text: i18n('Hibernate')
       }
       QQC2.CheckBox {
         id: showRestart

--- a/package/contents/ui/config/ConfigOverrides.qml
+++ b/package/contents/ui/config/ConfigOverrides.qml
@@ -13,6 +13,7 @@ KCM.SimpleKCM {
   property alias cfg_appStore: appStore.text
   property alias cfg_forceQuit: forceQuit.text
   property alias cfg_sleep: sleep.text
+  property alias cfg_hibernate: hibernate.text
   property alias cfg_restart: restart.text
   property alias cfg_shutDown: shutDown.text
   property alias cfg_lockScreen: lockScreen.text
@@ -57,6 +58,14 @@ KCM.SimpleKCM {
     QQC2.TextField {
       id: sleep
       Layout.fillWidth: true
+    }
+
+    Rectangle { Layout.bottomMargin: 5 }
+
+    QQC2.Label { text: i18n('Hibernate:') }
+    QQC2.TextField {
+        id: hibernate
+        Layout.fillWidth: true
     }
 
     Rectangle { Layout.bottomMargin: 5 }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -18,6 +18,7 @@ PlasmoidItem  {
   property bool showAppStore: plasmoid.configuration.showAppStore
   property bool showForceQuit: plasmoid.configuration.showForceQuit
   property bool showSleep: plasmoid.configuration.showSleep
+  property bool showHibernate: plasmoid.configuration.showHibernate
   property bool showRestart: plasmoid.configuration.showRestart
   property bool showShutdown: plasmoid.configuration.showShutdown
   property bool showLockScreen: plasmoid.configuration.showLockScreen
@@ -141,6 +142,14 @@ PlasmoidItem  {
       }
 
       ListDelegate {
+        text: i18n("Hibernate")
+        highlight: delegateHighlight
+        icon: "system-hibernate"
+        onClicked: executable.exec(hibernate)
+        visible: showHibernate
+      }
+
+      ListDelegate {
         text: i18n("Restart...")
         highlight: delegateHighlight
         icon: "system-reboot"
@@ -163,7 +172,7 @@ PlasmoidItem  {
           implicitHeight: 1.1
           color: lineColor
         }
-        visible: showSleep || showRestart || showShutdown
+        visible: showSleep || showHibernate || showRestart || showShutdown
       }
 
       ListDelegate {


### PR DESCRIPTION
This pull request adds a new "Hibernate" option to the KMenu KDE Plasma widget. The hibernate option is configurable, allowing users who have set up hibernate mode to enable it. For users who do not use hibernate, this option can be unchecked in the widget configuration to hide it.

**Changes:**
- Added a checkbox for the hibernate option in the configuration UI.
- Updated the main QML file to handle the visibility and execution of the hibernate option.
- Ensured the configuration is saved and loaded correctly.

**Before:**
![KMenu-before](https://github.com/51n7/kMenu/assets/74422195/35d90e7a-201f-426e-99f9-7a986e73a673)

**After:**
![KMenu-after](https://github.com/51n7/kMenu/assets/74422195/0d38b1a3-d389-40fb-a345-e9e5410e6646)

**Testing:**
Tested the new hibernate option to ensure it works as expected. Users can now enable or disable the hibernate option through the configuration settings.