### PR TITLE
Update main.xml with correct power options

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -36,7 +36,7 @@
     </entry>
 
     <entry name="cmdList" type="StringList">
-      <default>kinfocenter,separator,systemsettings,plasma-discover,separator,xkill,separator,systemctl suspend,qdbus org.kde.LogoutPrompt /LogoutPrompt promptReboot,qdbus org.kde.LogoutPrompt /LogoutPrompt promptShutDown,separator,qdbus org.freedesktop.ScreenSaver /ScreenSaver Lock,qdbus org.kde.LogoutPrompt /LogoutPrompt promptLogout</default>
+      <default>kinfocenter,separator,systemsettings,plasma-discover,separator,xkill,separator,systemctl suspend,qdbus6 org.kde.LogoutPrompt /LogoutPrompt promptReboot,qdbus6 org.kde.LogoutPrompt /LogoutPrompt promptShutDown,separator,qdbus6 org.freedesktop.ScreenSaver /ScreenSaver Lock,qdbus6 org.kde.LogoutPrompt /LogoutPrompt promptLogout</default>
     </entry>
 
     <entry name="separatorList" type="StringList">


### PR DESCRIPTION
KDE6 uses Qt6 which uses the "qdbus6" command instead of "qdbus" Fixing the commands re-enables the power buttons functionality without having to download any extra tools.